### PR TITLE
Add per-editor configuration support

### DIFF
--- a/dist/angular2-tinymce.component.d.ts
+++ b/dist/angular2-tinymce.component.d.ts
@@ -12,14 +12,15 @@ import 'tinymce/plugins/lists/plugin.js';
 import 'tinymce/plugins/code/plugin.js';
 export declare class TinymceComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
     private zone;
-    private config;
+    private defaultConfig;
     elementId: string;
     editor: any;
+    config: TinymceOptions;
     private onTouchedCallback;
     private onChangeCallback;
     private innerValue;
     private options;
-    constructor(zone: NgZone, config: TinymceOptions);
+    constructor(zone: NgZone, defaultConfig: TinymceOptions);
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     value: any;

--- a/dist/angular2-tinymce.component.d.ts
+++ b/dist/angular2-tinymce.component.d.ts
@@ -12,15 +12,15 @@ import 'tinymce/plugins/lists/plugin.js';
 import 'tinymce/plugins/code/plugin.js';
 export declare class TinymceComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
     private zone;
-    private defaultConfig;
+    private options;
     elementId: string;
     editor: any;
     config: TinymceOptions;
     private onTouchedCallback;
     private onChangeCallback;
     private innerValue;
-    private options;
-    constructor(zone: NgZone, defaultConfig: TinymceOptions);
+    private mergedOptions;
+    constructor(zone: NgZone, options: TinymceOptions);
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     value: any;

--- a/dist/angular2-tinymce.component.d.ts
+++ b/dist/angular2-tinymce.component.d.ts
@@ -1,4 +1,4 @@
-import { OnDestroy, AfterViewInit, NgZone } from '@angular/core';
+import { OnDestroy, AfterViewInit, NgZone, OnInit } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { TinymceOptions } from './angular2-tinymce.config.interface';
 import 'tinymce/tinymce.min';
@@ -10,7 +10,7 @@ import 'tinymce/plugins/advlist/plugin.js';
 import 'tinymce/plugins/autoresize/plugin.js';
 import 'tinymce/plugins/lists/plugin.js';
 import 'tinymce/plugins/code/plugin.js';
-export declare class TinymceComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
+export declare class TinymceComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnDestroy {
     private zone;
     private options;
     elementId: string;
@@ -21,6 +21,7 @@ export declare class TinymceComponent implements ControlValueAccessor, AfterView
     private innerValue;
     private mergedOptions;
     constructor(zone: NgZone, options: TinymceOptions);
+    ngOnInit(): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     value: any;

--- a/dist/angular2-tinymce.component.d.ts
+++ b/dist/angular2-tinymce.component.d.ts
@@ -1,4 +1,4 @@
-import { OnDestroy, AfterViewInit, NgZone, OnInit } from '@angular/core';
+import { OnDestroy, AfterViewInit, NgZone } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { TinymceOptions } from './angular2-tinymce.config.interface';
 import 'tinymce/tinymce.min';
@@ -10,7 +10,7 @@ import 'tinymce/plugins/advlist/plugin.js';
 import 'tinymce/plugins/autoresize/plugin.js';
 import 'tinymce/plugins/lists/plugin.js';
 import 'tinymce/plugins/code/plugin.js';
-export declare class TinymceComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnDestroy {
+export declare class TinymceComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
     private zone;
     private options;
     elementId: string;
@@ -21,7 +21,6 @@ export declare class TinymceComponent implements ControlValueAccessor, OnInit, A
     private innerValue;
     private mergedOptions;
     constructor(zone: NgZone, options: TinymceOptions);
-    ngOnInit(): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     value: any;

--- a/dist/angular2-tinymce.component.js
+++ b/dist/angular2-tinymce.component.js
@@ -28,19 +28,22 @@ var noop = function () {
 };
 var TinymceComponent = /** @class */ (function () {
     function TinymceComponent(zone, options) {
-        var _this = this;
         this.zone = zone;
         this.options = options;
         this.elementId = 'tiny-' + Math.random().toString(36).substring(2);
         this.onTouchedCallback = noop;
         this.onChangeCallback = noop;
+        //
+    }
+    TinymceComponent_1 = TinymceComponent;
+    TinymceComponent.prototype.ngOnInit = function () {
+        var _this = this;
         this.mergedOptions = Object.assign(new angular2_tinymce_default_1.TinymceDefaultOptions(), this.options, this.config);
         this.mergedOptions.selector = '#' + this.elementId;
         this.mergedOptions.setup = function (editor) {
             _this.editor = editor;
             editor.on('change keyup', function () {
-                var content = editor.getContent();
-                _this.value = content;
+                _this.value = editor.getContent();
             });
             if (typeof _this.options.setup === 'function') {
                 _this.options.setup(editor);
@@ -55,8 +58,7 @@ var TinymceComponent = /** @class */ (function () {
         if (this.options.auto_focus) {
             this.mergedOptions.auto_focus = this.elementId;
         }
-    }
-    TinymceComponent_1 = TinymceComponent;
+    };
     TinymceComponent.prototype.ngAfterViewInit = function () {
         if (this.mergedOptions.baseURL) {
             tinymce.baseURL = this.mergedOptions.baseURL;

--- a/dist/angular2-tinymce.component.js
+++ b/dist/angular2-tinymce.component.js
@@ -26,15 +26,15 @@ require("tinymce/plugins/lists/plugin.js");
 require("tinymce/plugins/code/plugin.js");
 var noop = function () {
 };
-var TinymceComponent = TinymceComponent_1 = (function () {
-    function TinymceComponent(zone, config) {
+var TinymceComponent = /** @class */ (function () {
+    function TinymceComponent(zone, defaultConfig) {
         var _this = this;
         this.zone = zone;
-        this.config = config;
+        this.defaultConfig = defaultConfig;
         this.elementId = 'tiny-' + Math.random().toString(36).substring(2);
         this.onTouchedCallback = noop;
         this.onChangeCallback = noop;
-        this.options = Object.assign(new angular2_tinymce_default_1.TinymceDefaultOptions(), this.config);
+        this.options = Object.assign(new angular2_tinymce_default_1.TinymceDefaultOptions(), this.defaultConfig, this.config);
         this.options.selector = '#' + this.elementId;
         this.options.setup = function (editor) {
             _this.editor = editor;
@@ -42,20 +42,21 @@ var TinymceComponent = TinymceComponent_1 = (function () {
                 var content = editor.getContent();
                 _this.value = content;
             });
-            if (typeof _this.config.setup === 'function') {
-                _this.config.setup(editor);
+            if (typeof _this.options.setup === 'function') {
+                _this.options.setup(editor);
             }
         };
         this.options.init_instance_callback = function (editor) {
             editor && _this.value && editor.setContent(_this.value);
-            if (typeof _this.config.init_instance_callback === 'function') {
-                _this.config.init_instance_callback(editor);
+            if (typeof _this.options.init_instance_callback === 'function') {
+                _this.options.init_instance_callback(editor);
             }
         };
-        if (this.config.auto_focus) {
+        if (this.options.auto_focus) {
             this.options.auto_focus = this.elementId;
         }
     }
+    TinymceComponent_1 = TinymceComponent;
     TinymceComponent.prototype.ngAfterViewInit = function () {
         if (this.options.baseURL) {
             tinymce.baseURL = this.options.baseURL;
@@ -88,6 +89,9 @@ var TinymceComponent = TinymceComponent_1 = (function () {
     TinymceComponent.prototype.writeValue = function (value) {
         if (value !== this.innerValue) {
             this.innerValue = value;
+            if (!value) {
+                value = '';
+            }
             this.editor && this.editor.setContent(value);
         }
     };
@@ -97,23 +101,27 @@ var TinymceComponent = TinymceComponent_1 = (function () {
     TinymceComponent.prototype.registerOnTouched = function (fn) {
         this.onTouchedCallback = fn;
     };
+    __decorate([
+        core_1.Input(),
+        __metadata("design:type", Object)
+    ], TinymceComponent.prototype, "config", void 0);
+    TinymceComponent = TinymceComponent_1 = __decorate([
+        core_1.Component({
+            selector: 'app-tinymce',
+            template: '<div id="{{elementId}}"></div>',
+            providers: [
+                {
+                    provide: forms_1.NG_VALUE_ACCESSOR,
+                    useExisting: core_1.forwardRef(function () { return TinymceComponent_1; }),
+                    multi: true
+                }
+            ]
+        }),
+        __param(1, core_1.Inject('TINYMCE_CONFIG')),
+        __metadata("design:paramtypes", [core_1.NgZone, Object])
+    ], TinymceComponent);
     return TinymceComponent;
+    var TinymceComponent_1;
 }());
-TinymceComponent = TinymceComponent_1 = __decorate([
-    core_1.Component({
-        selector: 'app-tinymce',
-        template: '<div id="{{elementId}}"></div>',
-        providers: [
-            {
-                provide: forms_1.NG_VALUE_ACCESSOR,
-                useExisting: core_1.forwardRef(function () { return TinymceComponent_1; }),
-                multi: true
-            }
-        ]
-    }),
-    __param(1, core_1.Inject('TINYMCE_CONFIG')),
-    __metadata("design:paramtypes", [core_1.NgZone, Object])
-], TinymceComponent);
 exports.TinymceComponent = TinymceComponent;
-var TinymceComponent_1;
 //# sourceMappingURL=angular2-tinymce.component.js.map

--- a/dist/angular2-tinymce.component.js
+++ b/dist/angular2-tinymce.component.js
@@ -27,16 +27,16 @@ require("tinymce/plugins/code/plugin.js");
 var noop = function () {
 };
 var TinymceComponent = /** @class */ (function () {
-    function TinymceComponent(zone, defaultConfig) {
+    function TinymceComponent(zone, options) {
         var _this = this;
         this.zone = zone;
-        this.defaultConfig = defaultConfig;
+        this.options = options;
         this.elementId = 'tiny-' + Math.random().toString(36).substring(2);
         this.onTouchedCallback = noop;
         this.onChangeCallback = noop;
-        this.options = Object.assign(new angular2_tinymce_default_1.TinymceDefaultOptions(), this.defaultConfig, this.config);
-        this.options.selector = '#' + this.elementId;
-        this.options.setup = function (editor) {
+        this.mergedOptions = Object.assign(new angular2_tinymce_default_1.TinymceDefaultOptions(), this.options, this.config);
+        this.mergedOptions.selector = '#' + this.elementId;
+        this.mergedOptions.setup = function (editor) {
             _this.editor = editor;
             editor.on('change keyup', function () {
                 var content = editor.getContent();
@@ -46,22 +46,22 @@ var TinymceComponent = /** @class */ (function () {
                 _this.options.setup(editor);
             }
         };
-        this.options.init_instance_callback = function (editor) {
+        this.mergedOptions.init_instance_callback = function (editor) {
             editor && _this.value && editor.setContent(_this.value);
             if (typeof _this.options.init_instance_callback === 'function') {
                 _this.options.init_instance_callback(editor);
             }
         };
         if (this.options.auto_focus) {
-            this.options.auto_focus = this.elementId;
+            this.mergedOptions.auto_focus = this.elementId;
         }
     }
     TinymceComponent_1 = TinymceComponent;
     TinymceComponent.prototype.ngAfterViewInit = function () {
-        if (this.options.baseURL) {
-            tinymce.baseURL = this.options.baseURL;
+        if (this.mergedOptions.baseURL) {
+            tinymce.baseURL = this.mergedOptions.baseURL;
         }
-        tinymce.init(this.options);
+        tinymce.init(this.mergedOptions);
     };
     TinymceComponent.prototype.ngOnDestroy = function () {
         tinymce.remove(this.editor);

--- a/dist/angular2-tinymce.component.js
+++ b/dist/angular2-tinymce.component.js
@@ -94,7 +94,7 @@ var TinymceComponent = /** @class */ (function () {
             if (!value) {
                 value = '';
             }
-            this.editor && this.editor.setContent(value);
+            this.editor && this.editor.initialized && this.editor.setContent(value);
         }
     };
     TinymceComponent.prototype.registerOnChange = function (fn) {

--- a/dist/angular2-tinymce.component.js
+++ b/dist/angular2-tinymce.component.js
@@ -104,7 +104,7 @@ var TinymceComponent = /** @class */ (function () {
         this.onTouchedCallback = fn;
     };
     __decorate([
-        core_1.Input(),
+        core_1.Input('config'),
         __metadata("design:type", Object)
     ], TinymceComponent.prototype, "config", void 0);
     TinymceComponent = TinymceComponent_1 = __decorate([

--- a/dist/angular2-tinymce.component.js
+++ b/dist/angular2-tinymce.component.js
@@ -36,7 +36,7 @@ var TinymceComponent = /** @class */ (function () {
         //
     }
     TinymceComponent_1 = TinymceComponent;
-    TinymceComponent.prototype.ngOnInit = function () {
+    TinymceComponent.prototype.ngAfterViewInit = function () {
         var _this = this;
         this.mergedOptions = Object.assign(new angular2_tinymce_default_1.TinymceDefaultOptions(), this.options, this.config);
         this.mergedOptions.selector = '#' + this.elementId;
@@ -58,8 +58,6 @@ var TinymceComponent = /** @class */ (function () {
         if (this.options.auto_focus) {
             this.mergedOptions.auto_focus = this.elementId;
         }
-    };
-    TinymceComponent.prototype.ngAfterViewInit = function () {
         if (this.mergedOptions.baseURL) {
             tinymce.baseURL = this.mergedOptions.baseURL;
         }
@@ -104,7 +102,7 @@ var TinymceComponent = /** @class */ (function () {
         this.onTouchedCallback = fn;
     };
     __decorate([
-        core_1.Input('config'),
+        core_1.Input(),
         __metadata("design:type", Object)
     ], TinymceComponent.prototype, "config", void 0);
     TinymceComponent = TinymceComponent_1 = __decorate([

--- a/dist/angular2-tinymce.default.js
+++ b/dist/angular2-tinymce.default.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var TinymceDefaultOptions = (function () {
+var TinymceDefaultOptions = /** @class */ (function () {
     function TinymceDefaultOptions() {
         this.plugins = [
             'link',

--- a/dist/angular2-tinymce.module.js
+++ b/dist/angular2-tinymce.module.js
@@ -11,9 +11,10 @@ var common_1 = require("@angular/common");
 var angular2_tinymce_component_1 = require("./angular2-tinymce.component");
 var forms_1 = require("@angular/forms");
 var angular2_tinymce_default_1 = require("./angular2-tinymce.default");
-var TinymceModule = TinymceModule_1 = (function () {
+var TinymceModule = /** @class */ (function () {
     function TinymceModule() {
     }
+    TinymceModule_1 = TinymceModule;
     TinymceModule.withConfig = function (userConfig) {
         if (userConfig === void 0) { userConfig = {}; }
         return {
@@ -23,26 +24,26 @@ var TinymceModule = TinymceModule_1 = (function () {
             ]
         };
     };
+    TinymceModule = TinymceModule_1 = __decorate([
+        core_1.NgModule({
+            imports: [
+                common_1.CommonModule,
+                forms_1.FormsModule,
+                forms_1.ReactiveFormsModule
+            ],
+            declarations: [
+                angular2_tinymce_component_1.TinymceComponent
+            ],
+            exports: [
+                angular2_tinymce_component_1.TinymceComponent
+            ],
+            providers: [
+                { provide: 'TINYMCE_CONFIG', useClass: angular2_tinymce_default_1.TinymceDefaultOptions }
+            ]
+        })
+    ], TinymceModule);
     return TinymceModule;
+    var TinymceModule_1;
 }());
-TinymceModule = TinymceModule_1 = __decorate([
-    core_1.NgModule({
-        imports: [
-            common_1.CommonModule,
-            forms_1.FormsModule,
-            forms_1.ReactiveFormsModule
-        ],
-        declarations: [
-            angular2_tinymce_component_1.TinymceComponent
-        ],
-        exports: [
-            angular2_tinymce_component_1.TinymceComponent
-        ],
-        providers: [
-            { provide: 'TINYMCE_CONFIG', useClass: angular2_tinymce_default_1.TinymceDefaultOptions }
-        ]
-    })
-], TinymceModule);
 exports.TinymceModule = TinymceModule;
-var TinymceModule_1;
 //# sourceMappingURL=angular2-tinymce.module.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,296 @@
+{
+  "name": "angular2-tinymce",
+  "version": "2.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@angular/common": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.3.6.tgz",
+      "integrity": "sha1-7TfpMHx1Bt2DR5fBps9nXlK1tu4=",
+      "dev": true,
+      "requires": {
+        "tslib": "1.7.1"
+      }
+    },
+    "@angular/compiler": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.3.6.tgz",
+      "integrity": "sha1-vhcN8Ji3HoNczt8WjV+3sj5QRbg=",
+      "dev": true,
+      "requires": {
+        "tslib": "1.7.1"
+      }
+    },
+    "@angular/compiler-cli": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.3.6.tgz",
+      "integrity": "sha1-avpq72jdaB5hs5i+TWJw5choCxI=",
+      "dev": true,
+      "requires": {
+        "@angular/tsc-wrapped": "4.3.6",
+        "minimist": "1.2.0",
+        "reflect-metadata": "0.1.10"
+      }
+    },
+    "@angular/core": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.3.6.tgz",
+      "integrity": "sha1-u6xj1o0Pe8s4nRKzQghlK+MofpY=",
+      "dev": true,
+      "requires": {
+        "tslib": "1.7.1"
+      }
+    },
+    "@angular/forms": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-4.3.6.tgz",
+      "integrity": "sha1-DyDEWXwWoVJ0XXzZVVmFWgpcZoc=",
+      "dev": true,
+      "requires": {
+        "tslib": "1.7.1"
+      }
+    },
+    "@angular/platform-browser": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.3.6.tgz",
+      "integrity": "sha1-YVKx87eNAkb8XhUOL3ue1DN+O6Y=",
+      "dev": true,
+      "requires": {
+        "tslib": "1.7.1"
+      }
+    },
+    "@angular/platform-server": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-4.3.6.tgz",
+      "integrity": "sha1-Np1JhE8cCpoQx8upsMt4wlIHQaU=",
+      "dev": true,
+      "requires": {
+        "parse5": "3.0.2",
+        "tslib": "1.7.1",
+        "xhr2": "0.1.4"
+      }
+    },
+    "@angular/tsc-wrapped": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.3.6.tgz",
+      "integrity": "sha1-GqZuCrLEeZpK0UtnXhOVOqX81DY=",
+      "dev": true,
+      "requires": {
+        "tsickle": "0.21.6"
+      }
+    },
+    "@types/node": {
+      "version": "6.0.88",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
+      "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "parse5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
+      "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.88"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "reflect-metadata": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.10.tgz",
+      "integrity": "sha1-tPg3BEFqytiZiMmxVjXUfgO5NEo=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "rxjs": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
+      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.4"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+      "dev": true
+    },
+    "tinymce": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.6.6.tgz",
+      "integrity": "sha1-2SgvNXB77inT4VQv3tJJ4Khsr9Q="
+    },
+    "tsickle": {
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
+      "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.5.7",
+        "source-map-support": "0.4.18"
+      }
+    },
+    "tslib": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
+      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xhr2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
+      "dev": true
+    },
+    "zone.js": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.17.tgz",
+      "integrity": "sha1-TF5RhahX2o2nk9rzkZNxxaNrKgs=",
+      "dev": true
+    }
+  }
+}

--- a/src/angular2-tinymce.component.ts
+++ b/src/angular2-tinymce.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, AfterViewInit, forwardRef, NgZone, Inject } from '@angular/core';
+import {Component, OnDestroy, AfterViewInit, forwardRef, NgZone, Inject, Input} from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { TinymceDefaultOptions } from './angular2-tinymce.default';
 import { TinymceOptions } from './angular2-tinymce.config.interface';
@@ -32,6 +32,7 @@ const noop = () => {
 export class TinymceComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
 	public elementId: string = 'tiny-'+Math.random().toString(36).substring(2);
 	public editor: any;
+	@Input() config: TinymceOptions;
 
 	private onTouchedCallback: () => void = noop;
 	private onChangeCallback: (_: any) => void = noop;
@@ -40,9 +41,9 @@ export class TinymceComponent implements ControlValueAccessor, AfterViewInit, On
 	private options: any;
 	constructor(
 		private zone: NgZone,
-		@Inject('TINYMCE_CONFIG') private config: TinymceOptions
+		@Inject('TINYMCE_CONFIG') private defaultConfig: TinymceOptions
 	) {
-		this.options = Object.assign(new TinymceDefaultOptions(), this.config);
+		this.options = Object.assign(new TinymceDefaultOptions(), this.defaultConfig, this.config);
 		this.options.selector = '#' + this.elementId;
 		this.options.setup = editor => {
 			this.editor = editor;
@@ -50,17 +51,17 @@ export class TinymceComponent implements ControlValueAccessor, AfterViewInit, On
 				const content = editor.getContent();
 				this.value = content;
 			});
-			if (typeof this.config.setup === 'function') {
-				this.config.setup(editor);
+			if (typeof this.options.setup === 'function') {
+				this.options.setup(editor);
 			}
 		}
 		this.options.init_instance_callback = editor => {
 			editor && this.value && editor.setContent(this.value)
-			if (typeof this.config.init_instance_callback === 'function') {
-				this.config.init_instance_callback(editor);
+			if (typeof this.options.init_instance_callback === 'function') {
+				this.options.init_instance_callback(editor);
 			}
 		}
-		if (this.config.auto_focus) {
+		if (this.options.auto_focus) {
 			this.options.auto_focus = this.elementId;
 		}
 	}

--- a/src/angular2-tinymce.component.ts
+++ b/src/angular2-tinymce.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, AfterViewInit, forwardRef, NgZone, Inject, Input, OnInit} from '@angular/core';
+import {Component, OnDestroy, AfterViewInit, forwardRef, NgZone, Inject, Input} from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { TinymceDefaultOptions } from './angular2-tinymce.default';
 import { TinymceOptions } from './angular2-tinymce.config.interface';
@@ -29,7 +29,7 @@ const noop = () => {
 		}
 	]
 })
-export class TinymceComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnDestroy {
+export class TinymceComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
 	public elementId: string = 'tiny-'+Math.random().toString(36).substring(2);
 	public editor: any;
 	@Input() public config: TinymceOptions;
@@ -46,7 +46,7 @@ export class TinymceComponent implements ControlValueAccessor, OnInit, AfterView
 		//
 	}
 
-	ngOnInit() {
+	ngAfterViewInit() {
         this.mergedOptions = Object.assign(new TinymceDefaultOptions(), this.options, this.config);
         this.mergedOptions.selector = '#' + this.elementId;
         this.mergedOptions.setup = editor => {
@@ -67,9 +67,6 @@ export class TinymceComponent implements ControlValueAccessor, OnInit, AfterView
         if (this.options.auto_focus) {
             this.mergedOptions.auto_focus = this.elementId;
         }
-	}
-
-	ngAfterViewInit() {
 		if (this.mergedOptions.baseURL) {
 			tinymce.baseURL = this.mergedOptions.baseURL;
 		}

--- a/src/angular2-tinymce.component.ts
+++ b/src/angular2-tinymce.component.ts
@@ -102,7 +102,7 @@ export class TinymceComponent implements ControlValueAccessor, OnInit, AfterView
 			if(!value) {
 				value = '';
 			}
-			this.editor && this.editor.setContent(value);
+			this.editor && this.editor.initialized && this.editor.setContent(value);
 		}
 	}
 

--- a/src/angular2-tinymce.component.ts
+++ b/src/angular2-tinymce.component.ts
@@ -38,14 +38,14 @@ export class TinymceComponent implements ControlValueAccessor, AfterViewInit, On
 	private onChangeCallback: (_: any) => void = noop;
 	private innerValue: string;
 
-	private options: any;
+	private mergedOptions: any;
 	constructor(
 		private zone: NgZone,
-		@Inject('TINYMCE_CONFIG') private defaultConfig: TinymceOptions
+		@Inject('TINYMCE_CONFIG') private options: TinymceOptions
 	) {
-		this.options = Object.assign(new TinymceDefaultOptions(), this.defaultConfig, this.config);
-		this.options.selector = '#' + this.elementId;
-		this.options.setup = editor => {
+		this.mergedOptions = Object.assign(new TinymceDefaultOptions(), this.options, this.config);
+		this.mergedOptions.selector = '#' + this.elementId;
+		this.mergedOptions.setup = editor => {
 			this.editor = editor;
 			editor.on('change keyup', () => {
 				const content = editor.getContent();
@@ -55,23 +55,23 @@ export class TinymceComponent implements ControlValueAccessor, AfterViewInit, On
 				this.options.setup(editor);
 			}
 		}
-		this.options.init_instance_callback = editor => {
+		this.mergedOptions.init_instance_callback = editor => {
 			editor && this.value && editor.setContent(this.value)
 			if (typeof this.options.init_instance_callback === 'function') {
 				this.options.init_instance_callback(editor);
 			}
 		}
 		if (this.options.auto_focus) {
-			this.options.auto_focus = this.elementId;
+			this.mergedOptions.auto_focus = this.elementId;
 		}
 	}
 
 
 	ngAfterViewInit() {
-		if (this.options.baseURL) {
-			tinymce.baseURL = this.options.baseURL;
+		if (this.mergedOptions.baseURL) {
+			tinymce.baseURL = this.mergedOptions.baseURL;
 		}
-		tinymce.init(this.options);
+		tinymce.init(this.mergedOptions);
 	}
 
 	ngOnDestroy() {

--- a/src/angular2-tinymce.component.ts
+++ b/src/angular2-tinymce.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, AfterViewInit, forwardRef, NgZone, Inject, Input} from '@angular/core';
+import {Component, OnDestroy, AfterViewInit, forwardRef, NgZone, Inject, Input, OnInit} from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { TinymceDefaultOptions } from './angular2-tinymce.default';
 import { TinymceOptions } from './angular2-tinymce.config.interface';
@@ -29,10 +29,10 @@ const noop = () => {
 		}
 	]
 })
-export class TinymceComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
+export class TinymceComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnDestroy {
 	public elementId: string = 'tiny-'+Math.random().toString(36).substring(2);
 	public editor: any;
-	@Input() config: TinymceOptions;
+	@Input() public config: TinymceOptions;
 
 	private onTouchedCallback: () => void = noop;
 	private onChangeCallback: (_: any) => void = noop;
@@ -43,29 +43,31 @@ export class TinymceComponent implements ControlValueAccessor, AfterViewInit, On
 		private zone: NgZone,
 		@Inject('TINYMCE_CONFIG') private options: TinymceOptions
 	) {
-		this.mergedOptions = Object.assign(new TinymceDefaultOptions(), this.options, this.config);
-		this.mergedOptions.selector = '#' + this.elementId;
-		this.mergedOptions.setup = editor => {
-			this.editor = editor;
-			editor.on('change keyup', () => {
-				const content = editor.getContent();
-				this.value = content;
-			});
-			if (typeof this.options.setup === 'function') {
-				this.options.setup(editor);
-			}
-		}
-		this.mergedOptions.init_instance_callback = editor => {
-			editor && this.value && editor.setContent(this.value)
-			if (typeof this.options.init_instance_callback === 'function') {
-				this.options.init_instance_callback(editor);
-			}
-		}
-		if (this.options.auto_focus) {
-			this.mergedOptions.auto_focus = this.elementId;
-		}
+		//
 	}
 
+	ngOnInit() {
+        this.mergedOptions = Object.assign(new TinymceDefaultOptions(), this.options, this.config);
+        this.mergedOptions.selector = '#' + this.elementId;
+        this.mergedOptions.setup = editor => {
+            this.editor = editor;
+            editor.on('change keyup', () => {
+                this.value = editor.getContent();
+            });
+            if (typeof this.options.setup === 'function') {
+                this.options.setup(editor);
+            }
+        };
+        this.mergedOptions.init_instance_callback = editor => {
+            editor && this.value && editor.setContent(this.value);
+            if (typeof this.options.init_instance_callback === 'function') {
+                this.options.init_instance_callback(editor);
+            }
+        };
+        if (this.options.auto_focus) {
+            this.mergedOptions.auto_focus = this.elementId;
+        }
+	}
 
 	ngAfterViewInit() {
 		if (this.mergedOptions.baseURL) {
@@ -90,7 +92,7 @@ export class TinymceComponent implements ControlValueAccessor, AfterViewInit, On
 			this.zone.run(() => {
 				this.onChangeCallback(v);
 			});
-			
+
 		}
 	}
 	// From ControlValueAccessor interface

--- a/src/angular2-tinymce.module.ts
+++ b/src/angular2-tinymce.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { TinymceComponent } from './angular2-tinymce.component';

--- a/src/angular2-tinymce.module.ts
+++ b/src/angular2-tinymce.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import {NgModule, ModuleWithProviders, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { TinymceComponent } from './angular2-tinymce.component';


### PR DESCRIPTION
Every editor instance can be configured individually using property binding.

Note: Angular CLI might send an error when using AoT compilation: "Can't bind to 'config' since it isn't a known property of 'app-tinymce'." To prevent this, apply CUSTOM_ELEMENTS_SCHEMA on the module. Any help to figure out a decent solution to this issue is highly appreciated!